### PR TITLE
Avoid tracking .jekyll-cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _site
 .DS_Store
 .jekyll
+.jekyll-cache
 .jekyll-metadata
 .bundle
 .sass-cache


### PR DESCRIPTION
Might be useful to avoid students commiting this folder if they submit a PR
after having tested in local.